### PR TITLE
Add react-jsx-starter-kit to Laravel Community Starter Kits

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -84,6 +84,11 @@
             "title": "Modern React Starter Kit",
             "package": "shipfastlabs/modern-react-starter-kit",
             "repo": "shipfastlabs/modern-react-starter-kit"
+        },
+        {
+            "title": "React JSX Starter Kit",
+            "package": "YazidKHALDI/react-jsx-starter-kit",
+            "repo": "YazidKHALDI/react-jsx-starter-kit"
         }
     ]
 }


### PR DESCRIPTION
## Description  

This PR adds **React JSX Starter Kit**, a JSX-based Laravel + React starter kit, to the **Community Templates** section.  

##  About This Starter Kit  

- A **modern** and **lightweight** alternative to the official Laravel React starter.  
- Uses **JavaScript (.jsx)** instead of **TypeScript (.tsx)** for a simpler setup.  
- Includes **React 19, TailwindCSS, Inertia.js, and shadcn/ui** for an enhanced developer experience.  
- Optimized for **Laravel developers who prefer JavaScript over TypeScript**.  

##  Changes Made  

- Added **react-jsx-starter-kit** under **Community Templates** in `templates.json`.  

## Why This PR?  

This addition provides Laravel developers with another **option for using React with Laravel**, offering a **streamlined and JavaScript-friendly** starter kit.  
