### PR TITLE
Add the Fission Starter Kit

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -84,6 +84,11 @@
             "title": "Modern React Starter Kit",
             "package": "shipfastlabs/modern-react-starter-kit",
             "repo": "shipfastlabs/modern-react-starter-kit"
+        },
+        {
+            "title": "Fission",
+            "package": "joshcirre/fission",
+            "repo": "joshcirre/fission"
         }
     ]
 }


### PR DESCRIPTION
The Fission starter kit has been updated to reflect the new `laravel new --using` changes and can be added as a community package.