### PR TITLE
Added Laravel Breeze React Starter Kit

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -1,89 +1,96 @@
 {
-    "official": [{
-            "title": "React",
-            "package": "laravel/react-starter-kit",
-            "repo": "laravel/react-starter-kit"
-        },
-        {
-            "title": "Vue",
-            "package": "laravel/vue-starter-kit",
-            "repo": "laravel/vue-starter-kit"
-        },
-        {
-            "title": "Livewire",
-            "package": "laravel/livewire-starter-kit",
-            "repo": "laravel/livewire-starter-kit"
-        }
-    ],
-    "community": [{
-            "title": "Statamic",
-            "package": "statamic/statamic",
-            "repo": "statamic/statamic"
-        },
-        {
-            "title": "Cachet",
-            "package": "cachethq/cachet",
-            "repo": "cachethq/cachet"
-        },
-        {
-            "title": "Svelte",
-            "package": "oseughu/svelte-starter-kit",
-            "repo": "oseughu/svelte-starter-kit"
-        },
-        {
-            "title": "Wave",
-            "package": "devdojo/wave",
-            "repo": "thedevdojo/wave"
-        },
-        {
-            "title": "Genesis",
-            "package": "devdojo/genesis",
-            "repo": "thedevdojo/genesis"
-        },
-        {
-            "title": "Filament",
-            "package": "tnylea/filamentapp",
-            "repo": "tnylea/filamentapp"
-        },
-        {
-            "title": "Livewire Starter",
-            "package": "tnylea/livewire-starter",
-            "repo": "tnylea/livewire-starter"
-        },
-        {
-            "title": "Larasonic React",
-            "package": "shipfastlabs/larasonic-react",
-            "repo": "shipfastlabs/larasonic-react"
-        },
-        {
-            "title": "Larasonic Vue",
-            "package": "shipfastlabs/larasonic-vue",
-            "repo": "shipfastlabs/larasonic-vue"
-        },
-        {
-            "title": "TALL starter",
-            "package": "mortenebak/tallstarter",
-            "repo": "mortenebak/tallstarter"
-        },
-        {
-            "title": "Filament Zeus starters",
-            "package": "lara-zeus/zeus",
-            "repo": "lara-zeus/zeus"
-        },
-        {
-            "title": "Modern Livewire Starter Kit",
-            "package": "shipfastlabs/modern-livewire-starter-kit",
-            "repo": "shipfastlabs/modern-livewire-starter-kit"
-        },
-        {
-            "title": "Modern Vue Starter Kit",
-            "package": "shipfastlabs/modern-vue-starter-kit",
-            "repo": "shipfastlabs/modern-vue-starter-kit"
-        },
-        {
-            "title": "Modern React Starter Kit",
-            "package": "shipfastlabs/modern-react-starter-kit",
-            "repo": "shipfastlabs/modern-react-starter-kit"
-        }
-    ]
+  "official": [
+    {
+      "title": "React",
+      "package": "laravel/react-starter-kit",
+      "repo": "laravel/react-starter-kit"
+    },
+    {
+      "title": "Vue",
+      "package": "laravel/vue-starter-kit",
+      "repo": "laravel/vue-starter-kit"
+    },
+    {
+      "title": "Livewire",
+      "package": "laravel/livewire-starter-kit",
+      "repo": "laravel/livewire-starter-kit"
+    }
+  ],
+  "community": [
+    {
+      "title": "Statamic",
+      "package": "statamic/statamic",
+      "repo": "statamic/statamic"
+    },
+    {
+      "title": "Cachet",
+      "package": "cachethq/cachet",
+      "repo": "cachethq/cachet"
+    },
+    {
+      "title": "Svelte",
+      "package": "oseughu/svelte-starter-kit",
+      "repo": "oseughu/svelte-starter-kit"
+    },
+    {
+      "title": "Wave",
+      "package": "devdojo/wave",
+      "repo": "thedevdojo/wave"
+    },
+    {
+      "title": "Genesis",
+      "package": "devdojo/genesis",
+      "repo": "thedevdojo/genesis"
+    },
+    {
+      "title": "Filament",
+      "package": "tnylea/filamentapp",
+      "repo": "tnylea/filamentapp"
+    },
+    {
+      "title": "Livewire Starter",
+      "package": "tnylea/livewire-starter",
+      "repo": "tnylea/livewire-starter"
+    },
+    {
+      "title": "Larasonic React",
+      "package": "shipfastlabs/larasonic-react",
+      "repo": "shipfastlabs/larasonic-react"
+    },
+    {
+      "title": "Larasonic Vue",
+      "package": "shipfastlabs/larasonic-vue",
+      "repo": "shipfastlabs/larasonic-vue"
+    },
+    {
+      "title": "TALL starter",
+      "package": "mortenebak/tallstarter",
+      "repo": "mortenebak/tallstarter"
+    },
+    {
+      "title": "Filament Zeus starters",
+      "package": "lara-zeus/zeus",
+      "repo": "lara-zeus/zeus"
+    },
+    {
+      "title": "Modern Livewire Starter Kit",
+      "package": "shipfastlabs/modern-livewire-starter-kit",
+      "repo": "shipfastlabs/modern-livewire-starter-kit"
+    },
+    {
+      "title": "Modern Vue Starter Kit",
+      "package": "shipfastlabs/modern-vue-starter-kit",
+      "repo": "shipfastlabs/modern-vue-starter-kit"
+    },
+    {
+      "title": "Modern React Starter Kit",
+      "package": "shipfastlabs/modern-react-starter-kit",
+      "repo": "shipfastlabs/modern-react-starter-kit"
+    },
+    {
+      "title": "Laravel Breeze React Starter Kit",
+      "package": "luis-developer-08/breeze-react-jsx-starter-kit",
+      "repo": "luis-developer-08/breeze-react-jsx-starter-kit"
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds a Laravel Breeze React Starter Kit, providing a streamlined setup for Laravel applications with a React frontend using Inertia.js. The kit includes React 19, TailwindCSS 4, and Breeze for lightweight authentication and scaffolding.

Key Features:

Uses JSX instead of TSX for a JavaScript-first approach.
Includes Laravel 12 + Breeze for authentication.
Styled with TailwindCSS 4 for modern UI.
Powered by Vite for fast development.
Supports PHPUnit & Pest for testing.