### PR TITLE
Adding Feature Ninja React Starter Kit

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -154,6 +154,11 @@
             "title": "Tabler based Laravel starter kit",
             "package": "santosvilanculos/cuirass",
             "repo": "santosvilanculos/cuirass"
+        },
+        {
+            "title": "Feature Ninja React Starter Kit",
+            "package": "feature-ninja/react-starter-kit",
+            "repo": "feature-ninja/react-starter-kit"
         }
     ]
 }


### PR DESCRIPTION
I've been structuring my apps into multiple sections lately such as a control panel and a marketing section where each section has their own asset bundle to prevent issues with unrelated dependencies. Seeing how the `--using` flag was added I figured it might be useful to convert this into a starter kit.

The control panel in the starter kit is a restructured version the official [Laravel React Starter Kit](https://github.com/laravel/react-starter-kit), and the marketing section is just plain old blade with a basic Vite setup.

It includes a simple command to run the Vite dev server for both asset bundles at the same time (running on different ports):

```bash
php artisan bundle dev
```

All the HTTP code such as controllers, requests and their related test have been grouped together by feature. The benefit of this is that pretty much all related backend code is in the same directory, so navigating it becomes easier.

Let me know what you think!