### PR TITLE
React Mantine

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -124,6 +124,12 @@
             "title": "Blade Starter Kit (with FluxUI)",
             "package": "imacrayon/blade-starter-kit",
             "repo": "imacrayon/blade-starter-kit"
+        },
+        
+        {
+            "title": "React (Mantine) Starter Kit",
+            "package": "adrum/laravel-react-mantine-starter-kit",
+            "repo": "adrum/laravel-react-mantine-starter-kit"
         }
     ]
 }


### PR DESCRIPTION
The adds one of my starter kits, which replaces shadcn with [Mantine](https://mantine.dev) in the Official React Starter Kit.

https://github.com/adrum/laravel-react-mantine-starter-kit