### PR TITLE
Add Jetstream React TypeScript

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -124,6 +124,11 @@
             "title": "Blade Starter Kit (with FluxUI)",
             "package": "imacrayon/blade-starter-kit",
             "repo": "imacrayon/blade-starter-kit"
+        },
+        {
+            "title": "Jetstream React (TypeScript)",
+            "package": "adrum/laravel-jetstream-react-typescript",
+            "repo": "adrum/laravel-jetstream-react-typescript"
         }
     ]
 }


### PR DESCRIPTION
A starter kit for the Laravel framework using Jetstream, Inertia.js, React (TS), and HeadlessUI.