### PR TITLE
Add VueJS + DaisyUI Starter Kit

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -159,6 +159,11 @@
             "title": "Hotwire Starter Kit",
             "package": "hotwired-laravel/hotwire-starter-kit",
             "repo": "hotwired-laravel/hotwire-starter-kit"
+        },
+        {
+            "title": "VueJS DaisyUI Starter Kit",
+            "package": "marcos-aparicio/vue-daisyui-starter-kit",
+            "repo": "marcos-aparicio/vue-daisyui-starter-kit"
         }
     ]
 }


### PR DESCRIPTION
Added my Starter Kit for DaisyUI v5, which uses Tailwind 4 under the hood.

The codebase is mostly based on the official VueJS starter kit but refactored to use DaisyUI, so that theme changes are way easier.